### PR TITLE
Fix: Handle empty quickSightGroupArns

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -367,7 +367,7 @@ async function centralStack(input: { account: string, stack: string; region: str
 		if (quicksightUsersAndGroups.quickSightUsers != undefined) {
 			cmd = cmd + ' -c quickSightUserArns=' + quicksightUsersAndGroups.quickSightUsers.join(',');
 		}
-		if (quicksightUsersAndGroups.quickSightGroups != undefined) {
+		if (quicksightUsersAndGroups.quickSightGroups != undefined && quicksightUsersAndGroups.quickSightGroups.length > 0 ) {
 			cmd = cmd + ' -c quickSightGroupArns=' + quicksightUsersAndGroups.quickSightGroups?.join(',');
 		}
 		cmd=cmd+" --parameters OrganizationIdParameter="+organization.Id+" --parameters ScheduleParameter="+input.schedule+" --parameters OrganizationPayerAccountIdParameter="+ organization.MasterAccountId


### PR DESCRIPTION
This commit adds a condition to evaluate whether the user has QuickSight groups but didn't select any. This condition helps prevent the parameter from being empty when the user fails to select a group.

**Issue:**

This issue occurs when a user selects a user but fails to select a group. As a consequence, the parameter -c quickSightGroupArns is left empty, leading to failure in the stack.


*Description of changes:* This commit adds a condition to evaluate whether the user has QuickSight groups but didn't select any


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
